### PR TITLE
selection: don't compute range if edit area is empty of elements

### DIFF
--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -601,7 +601,7 @@
     
     fixRangeOverflow: function(range) {
         
-        if (this.contain && range) {
+        if (this.contain && this.contain.firstChild && range) {
             var containment = range.compareNode(this.contain);
             
             if (containment !== 2) {


### PR DESCRIPTION
fixRangeOverflow() would call some `rangy` functions with a null element,
even causing the wysithml5 constructor to fail.
