### PR TITLE
Added bower file. Fixes #5. 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "wysihtml5",
+  "version": "0.4.2",
+  "main": [
+    "dist/wysihtml5x-0.4.2.min.js",
+    "dist/wysihtml5x-0.4.2-toolbar.min.js"
+  ],
+  "dependencies": {
+  },
+  "homepage": "https://github.com/Edicy/wysihtml5",
+  "authors": [
+    "edicy"
+  ],
+  "description": "Open source rich text editor based on HTML5 and the progressive-enhancement approach. Uses a sophisticated security concept and aims to generate fully valid HTML5 markup by preventing unmaintainable tag soups and inline styles.",
+  "keywords": [
+    "wysiwyg"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "build",
+    "examples",
+    "test",
+    "Makefile",
+    "src"
+  ]
+}


### PR DESCRIPTION
For Future releases versions in the bower.json file should match with the tag name. 
Maybe the files in the dist folder should be cleaned up too for tags, thus users don't have to download all version.
