### PR TITLE
IE8 issue when wysihtml5 tried to call getAttibute on a boolean

### DIFF
--- a/src/toolbar/dialog.js
+++ b/src/toolbar/dialog.js
@@ -155,7 +155,7 @@
         }
 
         fieldName = field.getAttribute(ATTRIBUTE_FIELDS);
-        newValue  = this.elementToChange ? (this.elementToChange.getAttribute(fieldName) || "") : field.defaultValue;
+        newValue  = (this.elementToChange && typeof(this.elementToChange) !== 'boolean') ? (this.elementToChange.getAttribute(fieldName) || "") : field.defaultValue;
         field.value = newValue;
       }
     },


### PR DESCRIPTION
[This line](https://github.com/Edicy/wysihtml5/commit/b43ab939e5919c87035c88664b1ab7372b12d7c4#diff-da34feb2e61308baec3ec93125e6b91cL8124) calls `show` with a parameter that may be a boolean. This PR fixes the callee to deal with a potential boolean. Before that patch, it tried to call getAttribute on a boolean object with obviously fails.
