### PR TITLE
Parse html against parser rules by default when calling get/setValue

### DIFF
--- a/src/views/composer.js
+++ b/src/views/composer.js
@@ -30,7 +30,7 @@
     getValue: function(parse) {
       var value = this.isEmpty() ? "" : wysihtml5.quirks.getCorrectInnerHTML(this.element);
 
-      if (parse) {
+      if (typeof(parse) === 'undefined' || parse === true) {
         value = this.parent.parse(value);
       }
 
@@ -38,7 +38,7 @@
     },
 
     setValue: function(html, parse) {
-      if (parse) {
+      if (typeof(parse) === 'undefined' || parse === true) {
         html = this.parent.parse(html);
       }
 

--- a/src/views/textarea.js
+++ b/src/views/textarea.js
@@ -14,14 +14,14 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
 
   getValue: function(parse) {
     var value = this.isEmpty() ? "" : this.element.value;
-    if (parse) {
+    if (typeof(parse) === 'undefined' || parse === true) {
       value = this.parent.parse(value);
     }
     return value;
   },
 
   setValue: function(html, parse) {
-    if (parse) {
+    if (typeof(parse) === 'undefined' || parse === true) {
       html = this.parent.parse(html);
     }
     this.element.value = html;


### PR DESCRIPTION
I introduced a possible security flaw in a product in developement where I forgot to explicitly say to sanitise the input against the parser rules when calling `setValue`. It seems like the safe default is to sanitise the input unless the developer says not to and what most people would expect. In particular, the [security section of the documentation](https://github.com/edicy/wysihtml5/wiki/Security) says that bad tags are stripped out but currently this only applies if you know/remember to pass an extra true parameter to the `getValue`/`setValue` functions. This PR sets the opposite to be true; html is parsed by default but you can disable it if you need to.