### PR TITLE
Add event parameter to handleDeleteKeyPress

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -52,7 +52,7 @@
     }
   };
 
-  var handleDeleteKeyPress = function(selection, element) {
+  var handleDeleteKeyPress = function(event, selection, element) {
     if (selection.isCollapsed()) {
       if (selection.caretIsInTheBeginnig()) {
         event.preventDefault();
@@ -253,7 +253,7 @@
       }
       if (keyCode === 8) {
         // delete key
-        handleDeleteKeyPress(that.selection, element);
+        handleDeleteKeyPress(event, that.selection, element);
       } else if (keyCode === 9) {
         event.preventDefault();
         handleTabKeyDown(that, element);


### PR DESCRIPTION
Hitting back with no input triggers an error because no event object was
passed to the handler.
