### PR TITLE
Fixed src names in bower.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "wysihtml5x",
   "version": "0.4.5",
   "main": [
-    "dist/wysihtml5x-0.4.3.min.js",
-    "dist/wysihtml5x-0.4.3-toolbar.min.js"
+    "dist/wysihtml5x.min.js",
+    "dist/wysihtml5x-toolbar.min.js"
   ],
   "dependencies": {
   },


### PR DESCRIPTION
I removed the version number from the source name since the files in dist/ do not contain version numbers. Previously this would cause an obvious 404 error.
