### PR TITLE
Update parser options in advanced.js to match advanced_unwrap.js

### DIFF
--- a/parser_rules/advanced.js
+++ b/parser_rules/advanced.js
@@ -81,12 +81,19 @@ var wysihtml5ParserRules = {
      *    - add_class:        converts and deletes the given HTML4 attribute (align, clear, ...) via the given method to a css class
      *                        The following methods are implemented in wysihtml5.dom.parse:
      *                          - align_text:  converts align attribute values (right/left/center/justify) to their corresponding css class "wysiwyg-text-align-*")
-     *                            <p align="center">foo</p> ... becomes ... <p> class="wysiwyg-text-align-center">foo</p>
+     *                            <p align="center">foo</p> ... becomes ... <p class="wysiwyg-text-align-center">foo</p>
      *                          - clear_br:    converts clear attribute values left/right/all/both to their corresponding css class "wysiwyg-clear-*"
      *                            <br clear="all"> ... becomes ... <br class="wysiwyg-clear-both">
      *                          - align_img:    converts align attribute values (right/left) on <img> to their corresponding css class "wysiwyg-float-*"
-     *                          
+     *
+     *    - add_style:        converts and deletes the given HTML4 attribute (align) via the given method to a css style
+     *                        The following methods are implemented in wysihtml5.dom.parse:
+     *                          - align_text:  converts align attribute values (right/left/center) to their corresponding css style)
+     *                            <p align="center">foo</p> ... becomes ... <p style="text-align:center">foo</p>
+     *
      *    - remove:             removes the element and its content
+     *
+     *    - unwrap              removes element but leaves content
      *
      *    - rename_tag:         renames the element to the given tag
      *
@@ -100,6 +107,7 @@ var wysihtml5ParserRules = {
      *                            - href:           allows something like "mailto:bert@foo.com", "http://google.com", "/foobar.jpg"
      *                            - alt:            strips unwanted characters. if the attribute is not set, then it gets set (to ensure valid and compatible HTML)
      *                            - numbers:  ensures that the attribute only contains numeric characters
+     *                            - any:            allows anything to pass 
      */
     "tags": {
         "tr": {


### PR DESCRIPTION
I discovered the hard way that there are additional parser options in the documentation for advanced_unwrap.js that don't exist in advanced.js. I just copied the expanded documentation back into advanced.js.
