### PR TITLE
Test for undefined in focus method

### DIFF
--- a/src/views/view.js
+++ b/src/views/view.js
@@ -33,7 +33,7 @@ wysihtml5.views.View = Base.extend(
       return;
     }
 
-    try { this.element.focus(); } catch(e) {}
+    try { if(this.element) { this.element.focus(); } } catch(e) {}
   },
 
   hide: function() {


### PR DESCRIPTION
In current Chromium the focus method gets sometimes called with this set to window. Thus an exception is thrown, which is disturbing during debugging.

```
Uncaught TypeError: Cannot read property 'ownerDocument' of undefined 
```

This PR tests for undefined.
