### PR TITLE
Allow tel: scheme in links

### DIFF
--- a/src/dom/parse.js
+++ b/src/dom/parse.js
@@ -695,7 +695,7 @@ wysihtml5.dom.parse = function(elementOrHtml_current, config_current) {
     })(),
 
     href: (function() {
-      var REG_EXP = /^(#|\/|https?:\/\/|mailto:)/i;
+      var REG_EXP = /^(#|\/|https?:\/\/|mailto:|tel:)/i;
       return function(attributeValue) {
         if (!attributeValue || !attributeValue.match(REG_EXP)) {
           return null;


### PR DESCRIPTION
Updated attributeCheckMethods.href to allow tel: links in href attributes.
