### PR TITLE
added superscript and subscript commands to wysihtml

### DIFF
--- a/parser_rules/advanced.js
+++ b/parser_rules/advanced.js
@@ -557,6 +557,12 @@ var wysihtml5ParserRules = {
         },
         "header": {
             "rename_tag": "div"
+        },
+        "sub": {
+            "rename_tag": "sub"
+        },
+        "sup": {
+            "rename_tag": "sup"
         }
     }
 };

--- a/src/commands/subscript.js
+++ b/src/commands/subscript.js
@@ -1,0 +1,9 @@
+wysihtml5.commands.subscript = {
+  exec: function(composer, command) {
+    wysihtml5.commands.formatInline.execWithToggle(composer, command, "sub");
+  },
+
+  state: function(composer, command) {
+    return wysihtml5.commands.formatInline.state(composer, command, "sub");
+  }
+};

--- a/src/commands/superscript.js
+++ b/src/commands/superscript.js
@@ -1,0 +1,9 @@
+wysihtml5.commands.superscript = {
+  exec: function(composer, command) {
+    wysihtml5.commands.formatInline.execWithToggle(composer, command, "sup");
+  },
+
+  state: function(composer, command) {
+    return wysihtml5.commands.formatInline.state(composer, command, "sup");
+  }
+};


### PR DESCRIPTION
We want to adopt wysihtml at work. One of the features we wanted was subscript and superscript support. I tested and compiled this locally. To create a subscript or superscript control, add these lines to your toolbar:

``` html
    <a data-wysihtml5-command="superscript" title="sup">superscript</a>
    <a data-wysihtml5-command="subscript" title="sub">subscript</a>
```

Please let me know if I missed anything in regards to testing or project conventions. One thing I found when deploying locally is that I needed to also reference the toolbar.min.js lib like this:

``` html
<script src="wysihtml/parser_rules/advanced.js"></script>
<script src="wysihtml/dist/wysihtml.min.js"></script>
<script src="wysihtml/dist/wysihtml-toolbar.min.js"></script>
```

it appears thats the docs only specify the parser and main wysihtml lib.
