### PR TITLE
Fire "cancel" event instead of "hide" in toolbar dialogs

### DIFF
--- a/src/toolbar/dialog.js
+++ b/src/toolbar/dialog.js
@@ -190,7 +190,7 @@
       this.elementToChange = null;
       dom.removeClass(this.link, CLASS_NAME_OPENED);
       this.container.style.display = "none";
-      this.fire("hide");
+      this.fire("cancel");
     }
   });
 })(wysihtml5);


### PR DESCRIPTION
When a toolbar dialog gets closed by pressing the relative button on the toolbar menu, fire "cancel" event instead of "hide" in order to activate a (possibly) registered "cancel:dialog" callback.

Moreover, the "hide" event is never observed by the toolbar, that only reacts on "show", "save" and, finally, "cancel".