### PR TITLE
Remove event listener on document when the editor is removed.

### DIFF
--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -223,12 +223,16 @@
         }
       });
 
-      this.container.ownerDocument.addEventListener("click", function(event) {
+      function updateLinkStatesAndPreventFocus(event) {
         if (!wysihtml5.dom.contains(that.container, event.target) && !wysihtml5.dom.contains(that.composer.element, event.target)) {
           that._updateLinkStates();
           that._preventInstantFocus();
         }
-      }, false);
+      }
+      this.container.ownerDocument.addEventListener("click", updateLinkStatesAndPreventFocus, false);
+      this.editor.on("destroy:composer", function() {
+        that.container.ownerDocument.removeEventListener("click", updateLinkStatesAndPreventFocus);
+      });
 
       if (this.editor.config.handleTables) {
         editor.on("tableselect:composer", function() {


### PR DESCRIPTION
This partially addresses https://github.com/Voog/wysihtml/issues/109
There're probably more leaks, but this one was producing lots of WRONG_DOCUMENT_ERR and was adding another listener each time an editor was created, which is quite unfortunate for a single page application.