### PR TITLE
Introduce destroy method

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -197,6 +197,16 @@
       return this.currentView.hasPlaceholderSet();
     },
 
+    destroy: function() {
+      if (this.composer && this.composer.sandbox) {
+        this.composer.sandbox.destroy();
+      }
+      if (this.toolbar) {
+        this.toolbar.destroy();
+      }
+      this.off();
+    },
+
     parse: function(htmlOrElement, clearInternals) {
       var parseContext = (this.config.contentEditableMode) ? document : ((this.composer) ? this.composer.sandbox.getDocument() : null);
       var returnValue = this.config.parser(htmlOrElement, {

--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -223,12 +223,14 @@
         }
       });
 
-      this.container.ownerDocument.addEventListener("click", function(event) {
+      this._ownerDocumentClick = function(event) {
         if (!wysihtml5.dom.contains(that.container, event.target) && !wysihtml5.dom.contains(that.composer.element, event.target)) {
           that._updateLinkStates();
           that._preventInstantFocus();
         }
-      }, false);
+      };
+
+      this.container.ownerDocument.addEventListener("click", this._ownerDocumentClick, false);
 
       if (this.editor.config.handleTables) {
         editor.on("tableselect:composer", function() {
@@ -251,6 +253,10 @@
             }
           }, 0);
       });
+    },
+
+    destroy: function() {
+      this.container.ownerDocument.removeEventListener("click", this._ownerDocumentClick, false);
     },
 
     _hideAllDialogs: function() {


### PR DESCRIPTION
Using wysihtml in single page apps leads to memory leaks since certain event handlers and intervals are not correctly cleaned up. This will add a ``destroy`` method that can be called to clear leftovers.

Similar to #210