### PR TITLE
Block elements exit improvement

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -382,6 +382,12 @@ wysihtml5.browser = (function() {
       return isWebKit;
     },
 
+    // In all webkit browsers there are some places where caret can not be placed at the end of blocks and directly before block level element
+    //   when startContainer is element.
+    hasCaretBlockElementIssue: function() {
+      return isWebKit;
+    },
+
     supportsMutationEvents: function() {
       return ("MutationEvent" in window);
     },

--- a/src/dom/dom_node.js
+++ b/src/dom/dom_node.js
@@ -39,6 +39,12 @@
             }
           }
           return isVisible;
+        },
+        lineBreak: function() {
+          return node && node.nodeType === 1 && node.nodeName === "BR";
+        },
+        block: function() {
+          return node && node.nodeType === 1 && node.ownerDocument.defaultView.getComputedStyle(node).display === "block";
         }
       },
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -59,6 +59,9 @@
     parser:               wysihtml5.dom.parse,
     // By default wysihtml5 will insert a <br> for line breaks, set this to false to use <p>
     useLineBreaks:        true,
+    // Double enter (enter on blank line) exits block element in useLineBreaks mode.
+    // It enables a way of escaping out of block elements and splitting block elements
+    doubleLineBreakEscapesBlock: true,
     // Array (or single string) of stylesheet urls to be loaded in the editor's iframe
     stylesheets:          [],
     // Placeholder text to use, defaults to the placeholder attribute on the textarea element

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -472,6 +472,43 @@
       return (ret !== this.contain) ? ret : false;
     },
 
+    // Gather info about caret location (caret node, previous and next node)
+    getNodesNearCaret: function() {
+      if (!this.isCollapsed()) {
+        throw "Selection must be caret when using selection.getNodesNearCaret()";
+      }
+
+      var r = this.getOwnRanges(),
+          caretNode, prevNode, nextNode, offset;
+
+      if (r && r.length > 0) {
+        if (r[0].startContainer.nodeType === 1) {
+          caretNode = r[0].startContainer.childNodes[r[0].startOffset - 1];
+          if (!caretNode && r[0].startOffset === 0) {
+            // Is first position before all nodes
+            nextNode = r[0].startContainer.childNodes[0];
+          } else if (caretNode) {
+            prevNode = caretNode.previousSibling;
+            nextNode = caretNode.nextSibling;
+          }
+        } else {
+          caretNode = r[0].startContainer;
+          prevNode = caretNode.previousSibling;
+          nextNode = caretNode.nextSibling;
+          offset = r[0].startOffset;
+        }
+
+        return {
+          "caretNode": caretNode,
+          "prevNode": prevNode,
+          "nextNode": nextNode,
+          "textOffset": offset
+        };
+      }
+
+      return null;
+    },
+
     getSelectionParentsByTag: function(tagName) {
       var nodes = this.getSelectedOwnNodes(),
           curEl, parents = [];

--- a/src/views/composer.js
+++ b/src/views/composer.js
@@ -441,7 +441,7 @@
       dom.observe(this.element, "keydown", function(event) {
         var keyCode = event.keyCode;
 
-        if (event.shiftKey || event.defaultPrevented) {
+        if (event.shiftKey || event.ctrlKey || event.defaultPrevented) {
           return;
         }
 

--- a/src/views/composer.js
+++ b/src/views/composer.js
@@ -419,18 +419,21 @@
         }
       }
 
+      // Ensures when editor is empty and not line breaks mode, the inital state has a paragraph in it on focus with caret inside paragraph
       if (!this.config.useLineBreaks) {
-        dom.observe(this.element, ["focus", "keydown"], function() {
+        dom.observe(this.element, ["focus"], function() {
           if (that.isEmpty()) {
-            var paragraph = that.doc.createElement("P");
-            that.element.innerHTML = "";
-            that.element.appendChild(paragraph);
-            if (!browser.displaysCaretInEmptyContentEditableCorrectly()) {
-              paragraph.innerHTML = "<br>";
-              that.selection.setBefore(paragraph.firstChild);
-            } else {
-              that.selection.selectNode(paragraph, true);
-            }
+            setTimeout(function() {
+              var paragraph = that.doc.createElement("P");
+              that.element.innerHTML = "";
+              that.element.appendChild(paragraph);
+              if (!browser.displaysCaretInEmptyContentEditableCorrectly()) {
+                paragraph.innerHTML = "<br>";
+                that.selection.setBefore(paragraph.firstChild);
+              } else {
+                that.selection.selectNode(paragraph, true);
+              }
+            }, 0);
           }
         });
       }
@@ -438,7 +441,7 @@
       dom.observe(this.element, "keydown", function(event) {
         var keyCode = event.keyCode;
 
-        if (event.shiftKey) {
+        if (event.shiftKey || event.defaultPrevented) {
           return;
         }
 

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -194,10 +194,9 @@
       // Fixes some misbehaviours of enters in linebreaks mode (natively a bit unsupported feature)
 
       var breakNodes = "p, pre, div, blockquote",
-          r = composer.selection.getOwnRanges(),
           caretInfo, parent, txtNode;
 
-      if (composer.selection.isCollapsed() && r && r.length > 0) {
+      if (composer.selection.isCollapsed()) {
         caretInfo = composer.selection.getNodesNearCaret();
         if (caretInfo) {
           

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -195,72 +195,62 @@
 
       var breakNodes = "p, pre, div, blockquote",
           r = composer.selection.getOwnRanges(),
-          caretNode, prevNode, nextNode, parent, txtNode;
+          caretInfo, parent, txtNode;
 
       if (composer.selection.isCollapsed() && r && r.length > 0) {
-
-        // Gather info about caret location for further modifications
-        if (r[0].startContainer.nodeType === 1) {
-          caretNode = r[0].startContainer.childNodes[r[0].startOffset - 1];
-          if (!caretNode && r[0].startOffset === 0) {
-            // Is first position before all nodes
-            nextNode = r[0].startContainer.childNodes[0];
-          } else if (caretNode) {
-            prevNode = caretNode.previousSibling;
-            nextNode = caretNode.nextSibling;
-          }
-        } else {
-          caretNode = r[0].startContainer;
-          prevNode = caretNode.previousSibling;
-          nextNode = caretNode.nextSibling;
-        }
-        if (caretNode || nextNode) {
-          parent = dom.getParentElement(caretNode || nextNode, { query: breakNodes }, 2);
-          if (parent === composer.element) {
-            parent = undefined;
-          }
-        }
-
-        if (parent && caretNode) {
-          if (domNode(caretNode).is.lineBreak()) {
-
-            if (composer.config.doubleLineBreakEscapesBlock) {
-              // Double enter (enter on blank line) exits block element in useLineBreaks mode.
-              event.preventDefault();
-              caretNode.parentNode.removeChild(caretNode);
-
-              var brNode = composer.doc.createElement('br');
-              if (domNode(nextNode).is.lineBreak() && nextNode === parent.lastChild) {
-                parent.parentNode.insertBefore(brNode, parent.nextSibling);
-              } else {
-                composer.selection.splitElementAtCaret(parent, brNode);
-              }
-
-              // Ensure surplous lines are not added to preceding element
-              if (domNode(nextNode).is.lineBreak()) {
-                //nextNode.parentNode.removeChild(nextNode);
-              } else if (nextNode && nextNode.nodeType === 3) {
-                // Replaces blank lines at the beginning of textnode
-                nextNode.data = nextNode.data.replace(/^ *[\r\n]+/, '');
-              }
-              composer.selection.setBefore(brNode);
+        caretInfo = composer.selection.getNodesNearCaret();
+        if (caretInfo) {
+          
+          if (caretInfo.caretNode || caretInfo.nextNode) {
+            parent = dom.getParentElement(caretInfo.caretNode || caretInfo.nextNode, { query: breakNodes }, 2);
+            if (parent === composer.element) {
+              parent = undefined;
             }
-
-          } else if (caretNode.nodeType === 3 && wysihtml5.browser.hasCaretBlockElementIssue() && r[0].startOffset === caretNode.data.length && !nextNode) {
-
-            // This fixes annoying webkit issue when you press enter at the end of a block then seemingly nothing happens.
-            // in reality one line break is generated and cursor is reported after it, but when entering something cursor jumps before the br
-            event.preventDefault();
-            var br1 = composer.doc.createElement('br'),
-                br2 = composer.doc.createElement('br'),
-                f = composer.doc.createDocumentFragment();
-            f.appendChild(br1);
-            f.appendChild(br2);
-            composer.selection.insertNode(f);
-            composer.selection.setBefore(br2);
-
           }
 
+          if (parent && caretInfo.caretNode) {
+            if (domNode(caretInfo.caretNode).is.lineBreak()) {
+
+              if (composer.config.doubleLineBreakEscapesBlock) {
+                // Double enter (enter on blank line) exits block element in useLineBreaks mode.
+                event.preventDefault();
+                caretInfo.caretNode.parentNode.removeChild(caretInfo.caretNode);
+                
+                // Ensure surplous line breaks are not added to preceding element
+                if (domNode(caretInfo.nextNode).is.lineBreak()) {
+                  caretInfo.nextNode.parentNode.removeChild(caretInfo.nextNode);
+                }
+
+                var brNode = composer.doc.createElement('br');
+                if (domNode(caretInfo.nextNode).is.lineBreak() && caretInfo.nextNode === parent.lastChild) {
+                  parent.parentNode.insertBefore(brNode, parent.nextSibling);
+                } else {
+                  composer.selection.splitElementAtCaret(parent, brNode);
+                }
+
+                // Ensure surplous blank lines are not added to preceding element
+                if (caretInfo.nextNode && caretInfo.nextNode.nodeType === 3) {
+                  // Replaces blank lines at the beginning of textnode
+                  caretInfo.nextNode.data = caretInfo.nextNode.data.replace(/^ *[\r\n]+/, '');
+                }
+                composer.selection.setBefore(brNode);
+              }
+
+            } else if (caretInfo.caretNode.nodeType === 3 && wysihtml5.browser.hasCaretBlockElementIssue() && caretInfo.textOffset === caretInfo.caretNode.data.length && !caretInfo.nextNode) {
+
+              // This fixes annoying webkit issue when you press enter at the end of a block then seemingly nothing happens.
+              // in reality one line break is generated and cursor is reported after it, but when entering something cursor jumps before the br
+              event.preventDefault();
+              var br1 = composer.doc.createElement('br'),
+                  br2 = composer.doc.createElement('br'),
+                  f = composer.doc.createDocumentFragment();
+              f.appendChild(br1);
+              f.appendChild(br2);
+              composer.selection.insertNode(f);
+              composer.selection.setBefore(br2);
+
+            }
+          }
         }
       }
     }

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -190,7 +190,7 @@
   };
 
   var handleEnterKeyPress = function(event, composer) {
-    if (composer.config.useLineBreaks && !event.shiftKey) {
+    if (composer.config.useLineBreaks && !event.shiftKey && !event.ctrlKey) {
       var breakNodes = "p, pre, div, blockquote",
           r = composer.selection.getOwnRanges(),
           caretNode, prevNode, nextNode, parent, txtNode;


### PR DESCRIPTION
Double enter (enter on blank line) exits block element in lineBreak mode. It enables a way of escaping out of block elements and splitting block elements