### PR TITLE
Fixed bug with getValue() failing when in sourceview

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -153,6 +153,10 @@
     },
 
     getValue: function(parse, clearInternals) {
+      // Check which editor to get value from
+      if (this.currentView == "source") {
+        return this.sourceView.textarea.value;
+      }
       return this.currentView.getValue(parse, clearInternals);
     },
 


### PR DESCRIPTION
This fixes the bug where `editor.getValue()` fails when the editor is in source view (contenteditable mode).