### PR TITLE
Fix destroy:composer event not being fired

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -534,7 +534,7 @@
     this.focusState = this.getValue(false, false);
 
     // --------- destroy:composer event ---------
-    container.addEventListener(["DOMNodeRemoved"], handleDomNodeRemoved.bind(this), false);
+    container.addEventListener("DOMNodeRemoved", handleDomNodeRemoved.bind(this), false);
 
     // DOMNodeRemoved event is not supported in IE 8
     // TODO: try to figure out a polyfill style fix, so it could be transferred to polyfills and removed if ie8 is not needed

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -535,6 +535,7 @@
 
     // --------- destroy:composer event ---------
     container.addEventListener("DOMNodeRemoved", handleDomNodeRemoved.bind(this), false);
+    container.addEventListener("DOMNodeRemovedFromDocument", handleDomNodeRemoved.bind(this), false);
 
     // DOMNodeRemoved event is not supported in IE 8
     // TODO: try to figure out a polyfill style fix, so it could be transferred to polyfills and removed if ie8 is not needed


### PR DESCRIPTION
This pull-request fixes two issues:

- The `destroy:composer` event is not being fired when the node is removed, as addEventListener only accepts a `string` as `type`;
- The `destroy:composer` event is not fired if any of it's parents is removed from the document.

Please, note that:
The DOMNodeRemoved has been kept to cover the case where the element is removed from a currently detached parent.