### PR TITLE
Fixing IE logic for list item deletion

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -95,7 +95,7 @@ wysihtml5.polyfills = function(win, doc) {
     };
   }
 
-  // closest and matches polyfill
+  // closest, matches, and remove polyfill
   // https://github.com/jonathantneal/closest
   (function (ELEMENT) {
     ELEMENT.matches = ELEMENT.matches || ELEMENT.mozMatchesSelector || ELEMENT.msMatchesSelector || ELEMENT.oMatchesSelector || ELEMENT.webkitMatchesSelector || function matches(selector) {
@@ -124,7 +124,14 @@ wysihtml5.polyfills = function(win, doc) {
 
       return element;
     };
-  }(Element.prototype));
+
+    ELEMENT.remove = ELEMENT.remove || function remove() {
+      if (this.parentNode) {
+        this.parentNode.removeChild(this);
+      }
+    };
+
+  }(win.Element.prototype));
 
   // Element.classList for ie8-9 (toggle all IE)
   // source http://purl.eligrey.com/github/classList.js/blob/master/classList.js

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -120,7 +120,9 @@
         var selection = composer.selection.getSelection(),
             aNode = selection.anchorNode,
             listNode, prevNode, firstNode,
-            isInBeginnig = composer.selection.caretIsFirstInSelection();
+            isInBeginnig = composer.selection.caretIsFirstInSelection(),
+            prevNode,
+            intermediaryNode;
 
         // Fix caret at the beginnig of first textNode in LI
         if (aNode.nodeType === 3 && selection.anchorOffset === 0 && aNode === aNode.parentNode.firstChild) {
@@ -132,10 +134,16 @@
           prevNode = domNode(aNode).prev({nodeTypes: [1,3], ignoreBlankTexts: true});
           if (!prevNode && aNode.parentNode && (aNode.parentNode.nodeName === "UL" || aNode.parentNode.nodeName === "OL")) {
             prevNode = domNode(aNode.parentNode).prev({nodeTypes: [1,3], ignoreBlankTexts: true});
+            intermediaryNode = aNode.parentNode;
           }
           if (prevNode) {
             firstNode = aNode.firstChild;
             domNode(aNode).transferContentTo(prevNode, true);
+
+            if (intermediaryNode && intermediaryNode.children.length === 0){
+              intermediaryNode.remove();
+            }
+
             if (firstNode) {
               composer.selection.setBefore(firstNode);
             } else if (prevNode) {
@@ -147,6 +155,12 @@
                 }
               } else {
                 composer.selection.setAfter(prevNode);
+              }
+            } else {
+              domNode(aNode).transferContentTo(aNode.parentNode.parentNode, true);
+
+              if (intermediaryNode && intermediaryNode.children.length === 0){
+                intermediaryNode.remove();
               }
             }
             return true;

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -156,7 +156,7 @@
               } else {
                 composer.selection.setAfter(prevNode);
               }
-            } 
+            }
             return true;
           }
         }

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -156,13 +156,7 @@
               } else {
                 composer.selection.setAfter(prevNode);
               }
-            } else {
-              domNode(aNode).transferContentTo(aNode.parentNode.parentNode, true);
-
-              if (intermediaryNode && intermediaryNode.children.length === 0){
-                intermediaryNode.remove();
-              }
-            }
+            } 
             return true;
           }
         }


### PR DESCRIPTION
This fixes an issue with node.matches in IE (mentioned in #286) as well as some inconsistencies in the list item deletion logic for IE where some empty list tags would remain after deletion.