### PR TITLE
Updating focusing on original element to use focusWithoutScrolling in composer.style

### DIFF
--- a/src/views/composer.style.js
+++ b/src/views/composer.style.js
@@ -165,7 +165,7 @@
 
     // --------- restore focus ---------
     if (originalActiveElement) {
-      originalActiveElement.focus();
+      focusWithoutScrolling(originalActiveElement);
     } else {
       textareaElement.blur();
     }


### PR DESCRIPTION
This was causing an issue when the wysiwyg editor was loaded after the initial page load in which the user would be scroll back to the top of the page.