### PR TITLE
Fix for handleDomNodeRemoved not being called when parent containers removed from DOM

### DIFF
--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -334,7 +334,7 @@
     composer.commands.exec("insertHTML", "&emsp;");
   };
 
-  var handleDomNodeRemoved = function(event) {
+  var handleDomNodeRemoved = function(event) {      
       if (this.domNodeRemovedInterval) {
         clearInterval(domNodeRemovedInterval);
       }
@@ -595,8 +595,9 @@
     this.focusState = this.getValue(false, false);
     this.actions = actions;
 
-    // --------- destroy:composer event ---------
+    // --------- destroy:composer event ---------    
     container.addEventListener(["DOMNodeRemoved"], handleDomNodeRemoved.bind(this), false);
+    container.addEventListener(["DOMNodeRemovedFromDocument"], handleDomNodeRemoved.bind(this), false);
 
     // DOMNodeRemoved event is not supported in IE 8
     // TODO: try to figure out a polyfill style fix, so it could be transferred to polyfills and removed if ie8 is not needed

--- a/src/views/composer.observe.js
+++ b/src/views/composer.observe.js
@@ -334,7 +334,7 @@
     composer.commands.exec("insertHTML", "&emsp;");
   };
 
-  var handleDomNodeRemoved = function(event) {      
+  var handleDomNodeRemoved = function(event) {
       if (this.domNodeRemovedInterval) {
         clearInterval(domNodeRemovedInterval);
       }
@@ -595,7 +595,7 @@
     this.focusState = this.getValue(false, false);
     this.actions = actions;
 
-    // --------- destroy:composer event ---------    
+    // --------- destroy:composer event ---------
     container.addEventListener(["DOMNodeRemoved"], handleDomNodeRemoved.bind(this), false);
     container.addEventListener(["DOMNodeRemovedFromDocument"], handleDomNodeRemoved.bind(this), false);
 


### PR DESCRIPTION
WYSIHTML editors created on textareas inside jconfirm dialog boxes were not being properly destroyed when the dialog is closed.

The scenario can be recreated quite easily in the simple example (http://voog.github.io/wysihtml/examples/simple.html) by deleting the form element rather than its child elements.

Browser stacktrace after destroying the dialog/container was:

> wysihtml.js:10009 Uncaught TypeError: Cannot read property 'document' of null
> getDocument @ wysihtml.js:10009
> wysihtml.Editor.wysihtml.lang.Dispatcher.extend.parse @ wysihtml.js:16047
> wysihtml.views.Textarea.wysihtml.views.View.extend.setValue @ wysihtml.js:15793
> wysihtml.views.Synchronizer.Base.extend.fromComposerToTextarea @ wysihtml.js:15638
> (anonymous function) @ wysihtml.js:15678