### PR TITLE
fix: beforepaste double-fire by IE 11 discards caret position

### DIFF
--- a/src/dom/get_pasted_html.js
+++ b/src/dom/get_pasted_html.js
@@ -1,9 +1,9 @@
-/* 
+/*
  * Methods for fetching pasted html before it gets inserted into content
 **/
 
 /* Modern event.clipboardData driven approach.
- * Advantage is that it does not have to loose selection or modify dom to catch the data. 
+ * Advantage is that it does not have to loose selection or modify dom to catch the data.
  * IE does not support though.
 **/
 wysihtml.dom.getPastedHtml = function(event) {
@@ -18,13 +18,19 @@ wysihtml.dom.getPastedHtml = function(event) {
   return html;
 };
 
+wysihtml.dom.cleanerDivs = [];
+wysihtml.dom.isCleanerDiv = function(element) {
+  return this.cleanerDivs.indexOf(element) !== -1;
+};
 /* Older temprorary contenteditable as paste source catcher method for fallbacks */
 wysihtml.dom.getPastedHtmlWithDiv = function (composer, f) {
   var selBookmark = composer.selection.getBookmark(),
       doc = composer.element.ownerDocument,
       cleanerDiv = doc.createElement('DIV'),
       scrollPos = composer.getScrollPos();
-  
+
+  this.cleanerDivs.push(cleanerDiv);
+
   doc.body.appendChild(cleanerDiv);
 
   cleanerDiv.style.width = "1px";
@@ -46,6 +52,7 @@ wysihtml.dom.getPastedHtmlWithDiv = function (composer, f) {
       html = false;
     }
     f(html);
+    wysihtml.dom.cleanerDivs.splice(wysihtml.dom.cleanerDivs.indexOf(cleanerDiv), 1);
     cleanerDiv.parentNode.removeChild(cleanerDiv);
   }, 0);
 };

--- a/src/editor.js
+++ b/src/editor.js
@@ -78,12 +78,12 @@
         uneditableContainer: "wysihtml-uneditable-container"
       },
       // Browsers that support copied source handling will get a marking of the origin of the copied source (for determinig code cleanup rules on paste)
-      // Also copied source is based directly on selection - 
+      // Also copied source is based directly on selection -
       // (very useful for webkit based browsers where copy will otherwise contain a lot of code and styles based on whatever and not actually in selection).
       // If falsy value is passed source override is also disabled
       copyedFromMarking: '<meta name="copied-from" content="wysihtml">'
     },
-    
+
     constructor: function(editableElement, config) {
       this.editableElement  = typeof(editableElement) === "string" ? document.getElementById(editableElement) : editableElement;
       this.config           = wysihtml.lang.object({}).merge(this.defaults).merge(config).get();
@@ -131,7 +131,7 @@
         }
         this.runEditorExtenders();
     },
-    
+
     runEditorExtenders: function() {
       wysihtml.editorExtenders.forEach(function(extender) {
         extender(this);
@@ -237,6 +237,10 @@
       } else {
         this.on("beforepaste:composer", function(event) {
           event.preventDefault();
+          // Ignore second beforepaste fired by IE11.
+          if(wysihtml.dom.isCleanerDiv(event.target)) {
+            return;
+          }
           var scrollPos = this.composer.getScrollPos();
 
           wysihtml.dom.getPastedHtmlWithDiv(this.composer, function(pastedHTML) {


### PR DESCRIPTION
IE 11 fires the `beforepaste` event twice, once with the correct event target, and once with the temporary `contenteditable` div. This patch ignores the second event by keeping track of the temporary `contenteditable` divs.

This fixes text not getting pasted in the correct position in IE.