### PR TITLE
Make sure window still exists before getting document

### DIFF
--- a/src/dom/get_attribute.js
+++ b/src/dom/get_attribute.js
@@ -12,13 +12,7 @@ wysihtml.dom.getAttribute = function(node, attributeName) {
   var HAS_GET_ATTRIBUTE_BUG = !wysihtml.browser.supportsGetAttributeCorrectly();
   attributeName = attributeName.toLowerCase();
   var nodeName = node.nodeName;
-  if (nodeName == "IMG" && attributeName == "src" && wysihtml.dom.isLoadedImage(node) === true) {
-    // Get 'src' attribute value via object property since this will always contain the
-    // full absolute url (http://...)
-    // this fixes a very annoying bug in firefox (ver 3.6 & 4) and IE 8 where images copied from the same host
-    // will have relative paths, which the sanitizer strips out (see attributeCheckMethods.url)
-    return node.src;
-  } else if (HAS_GET_ATTRIBUTE_BUG && "outerHTML" in node) {
+  if (HAS_GET_ATTRIBUTE_BUG && "outerHTML" in node) {
     // Don't trust getAttribute/hasAttribute in IE 6-8, instead check the element's outerHTML
     var outerHTML      = node.outerHTML.toLowerCase(),
         // TODO: This might not work for attributes without value: <input disabled>

--- a/src/dom/get_attributes.js
+++ b/src/dom/get_attributes.js
@@ -17,9 +17,7 @@ wysihtml.dom.getAttributes = function(node) {
   for (attr in node.attributes) {
     if ((node.attributes.hasOwnProperty && node.attributes.hasOwnProperty(attr)) || (!node.attributes.hasOwnProperty && Object.prototype.hasOwnProperty.call(node.attributes, attr)))  {
       if (node.attributes[attr].specified) {
-        if (nodeName == "IMG" && node.attributes[attr].name.toLowerCase() == "src" && wysihtml.dom.isLoadedImage(node) === true) {
-          attributes['src'] = node.src;
-        } else if (wysihtml.lang.array(['rowspan', 'colspan']).contains(node.attributes[attr].name.toLowerCase()) && HAS_GET_ATTRIBUTE_BUG) {
+        if (wysihtml.lang.array(['rowspan', 'colspan']).contains(node.attributes[attr].name.toLowerCase()) && HAS_GET_ATTRIBUTE_BUG) {
           if (node.attributes[attr].value !== 1) {
             attributes[node.attributes[attr].name] = node.attributes[attr].value;
           }

--- a/src/dom/sandbox.js
+++ b/src/dom/sandbox.js
@@ -167,7 +167,12 @@
       iframeDocument.close();
 
       this.getWindow = function() { return iframe.contentWindow; };
-      this.getDocument = function() { return iframe.contentWindow.document; };
+      this.getDocument = function() {
+        var w = this.getWindow();
+        if(w !== null) {
+          return w.document;
+        }
+      };
 
       // Catch js errors and pass them to the parent's onerror event
       // addEventListener("error") doesn't work properly in some browsers


### PR DESCRIPTION
contentWindow might no longer exist resulting in errors like #44 and the error mentioned in #354
```
Uncaught TypeError: Cannot read property 'document' of null     wysihtml5x-toolbar-0.4.5.js:6712
getDocument                                                     wysihtml5x-toolbar-0.4.5.js:6712
wysihtml5.views.Composer.wysihtml5.views.View.extend._create    wysihtml5x-toolbar-0.4.5.js:11514
sandbox.dom.Sandbox.stylesheets                                 wysihtml5x-toolbar-0.4.5.js:11489
(anonymous function)                                            wysihtml5x-toolbar-0.4.5.js:6746
```